### PR TITLE
fix for broken /admin link in "Analytics, tags and comments" post

### DIFF
--- a/_posts/2016-08-01-analytics-tags-comments.md
+++ b/_posts/2016-08-01-analytics-tags-comments.md
@@ -22,7 +22,7 @@ To enable Yandex Metrica you need to register, create a 'counter' and then copy-
 
 # Tags
 
-To use this feature you simply will need to create a markdown file for each tag which you are using in you site in **tag** folder. To simplify this procedure there is an [/admin](http://pavelmakhov.com/jekyll-clean-dark/admin.html) page, which outputs the bash command which you just need to run inside **tag** folder of your site. Also don't forget to rerun it when you add a post with new tag.
+To use this feature you simply will need to create a markdown file for each tag which you are using in you site in **tag** folder. To simplify this procedure there is an [/admin]({{site.baseurl}}/admin) page, which outputs the bash command which you just need to run inside **tag** folder of your site. Also don't forget to rerun it when you add a post with new tag.
 
 # Comments
 


### PR DESCRIPTION
I just found an issue with admin page that is linked in "2016-08-01-analytics-tags-comments.md" post. It is linking to the domain you own (pavelmakhov.com).